### PR TITLE
Let undefined tags be just text instead of throwing.

### DIFF
--- a/src/Output.php
+++ b/src/Output.php
@@ -231,7 +231,11 @@ class Output
         $tags = $this->getTagsFromString($line);
 
         foreach ($tags as $tag) {
-            $code = $this->getCodeFor($tag);
+            try {
+                $code = $this->getCodeFor($tag);
+            } catch (Throwable $throwable) {
+                continue;
+            }
 
             $line = str_replace("<{$tag}>", $code, $line);
             $line = str_replace("</{$tag}>", $this->predefinedTags['default'], $line);
@@ -248,7 +252,8 @@ class Output
         foreach ($matches[0] as $tag) {
             $tags[] = trim($tag, '<>');
         }
-        return $tags;
+
+        return array_unique($tags);
     }
 
     protected function getCodeFor(string $tag): string

--- a/tests/OutputTest.php
+++ b/tests/OutputTest.php
@@ -320,9 +320,6 @@ class OutputTest extends AbstractTestClass
 
     public function testUnknownTags()
     {
-        self::expectException(\Parable\Console\Exception::class);
-        self::expectExceptionMessage('No predefined or tag set found for <tag>.');
-
         $output = $this->container->build(Output::class);
         $this->assertSame($this->addTag('<tag>unknown</tag>'), $output->parseTags('<tag>unknown</tag>'));
     }


### PR DESCRIPTION
Also unique on getTagsFromString because no need for duplicates.

Closes #1 